### PR TITLE
Tool JWT: Fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "jwt"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/tool-jwt/Cargo.toml
+++ b/crates/tool-jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jwt"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Breno RdV"]
 description = "Decodes JWT tokens and extracts their public claims, headers, and payload information. Optionally copies claims to clipboard."

--- a/crates/tool-jwt/changelog.md
+++ b/crates/tool-jwt/changelog.md
@@ -1,0 +1,2 @@
+# 1.0.1 (2025-09-04)
+- The name of the property to copy is now case insensitive.

--- a/crates/tool-jwt/changelog.md
+++ b/crates/tool-jwt/changelog.md
@@ -1,2 +1,3 @@
 # 1.0.1 (2025-09-04)
-- The name of the property to copy is now case insensitive.
+- The name of the property to copy is now case-insensitive.
+- Fixed copying string properties to the clipboard. Now we don't copy the quotes.

--- a/crates/tool-jwt/src/jwt_app.rs
+++ b/crates/tool-jwt/src/jwt_app.rs
@@ -120,12 +120,19 @@ pub fn print_token_json(claims: &Map<String, Value>) {
 /// Searches for claim key in token and copies its string value.
 /// Exits with error if claim not found or clipboard operation fails.
 pub fn copy_claim_to_clipboard(argument_to_copy: String, claims: &Map<String, Value>) {
-    if !claims.contains_key(&argument_to_copy) {
+    let mut value: &Value = &Value::Null;
+
+    for (key, claim_value) in claims {
+        if key.to_lowercase() != argument_to_copy.to_lowercase().trim() {
+            continue;
+        }
+        value = claim_value;
+    }
+
+    if value == &Value::Null {
         eprintln!("Claim not found: {}", argument_to_copy);
         return;
     }
-
-    let value = &claims[&argument_to_copy];
 
     let owned: String = value.to_string();
     let slice: &str = &owned; // but this owns a new String

--- a/crates/tool-jwt/src/jwt_app.rs
+++ b/crates/tool-jwt/src/jwt_app.rs
@@ -4,6 +4,7 @@ use colored::Colorize;
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde_json::{Map, Value};
 use shared::utils::copy_string_to_clipboard::copy_to_clipboard;
+use std::borrow::Cow;
 use std::process;
 
 /// Decodes JWT token without signature verification.
@@ -134,10 +135,13 @@ pub fn copy_claim_to_clipboard(argument_to_copy: String, claims: &Map<String, Va
         return;
     }
 
-    let owned: String = value.to_string();
-    let slice: &str = &owned; // but this owns a new String
+    let text_to_copy: Cow<'_, str> = match value {
+        // Added this treatment to avoid strings being copied to the clipboard with quotes.
+        Value::String(s) => Cow::Borrowed(s.as_str()),
+        _ => Cow::Owned(value.to_string()),
+    };
 
-    match copy_to_clipboard(slice) {
+    match copy_to_clipboard(text_to_copy.as_ref()) {
         Ok(_) => {}
         Err(e) => {
             eprintln!("📋 Error copying to clipboard: {}", e);


### PR DESCRIPTION
# 1.0.1 (2025-09-04)
- The name of the property to copy is now case-insensitive.
- Fixed copying string properties to the clipboard. Now we don't copy the quotes.